### PR TITLE
feat: add comprehensive collateral display in circle overview

### DIFF
--- a/src/components/CircleOverviewTab.tsx
+++ b/src/components/CircleOverviewTab.tsx
@@ -13,6 +13,7 @@ import { getFrequencyText } from "../utils/helpers";
 interface CircleOverviewTabProps {
   circle: ActiveCircle;
   colors: any;
+  collateralLocked: number;
   collateralRequired: number;
   minMembersToStart: number;
   ultimatumPeriod: string;
@@ -21,6 +22,7 @@ interface CircleOverviewTabProps {
 const CircleOverviewTab: React.FC<CircleOverviewTabProps> = ({
   circle,
   colors,
+  collateralLocked,
   collateralRequired,
   minMembersToStart,
   ultimatumPeriod,
@@ -178,6 +180,22 @@ const CircleOverviewTab: React.FC<CircleOverviewTabProps> = ({
             Security & Requirements
           </h3>
           <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span style={{ color: colors.textLight }}>
+                Initial Expected Members:
+              </span>
+              <span style={{ color: colors.text }}>
+                {circle.rawCircle?.maxMembers.toString() || "N/A"}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span style={{ color: colors.textLight }}>
+                Collateral Locked:
+              </span>
+              <span style={{ color: colors.text }}>
+                ${collateralLocked.toFixed(2)}
+              </span>
+            </div>
             <div className="flex justify-between">
               <span style={{ color: colors.textLight }}>
                 Collateral Required:

--- a/src/modals/CircleDetailsModal.tsx
+++ b/src/modals/CircleDetailsModal.tsx
@@ -165,11 +165,23 @@ const CircleDetailsModal: React.FC<CircleDetailsModalProps> = ({
   };
 
   const circleState = getCircleState(circle.status || "created");
+
+  // Collateral Locked: Based on maxMembers (what was originally proposed and locked)
+  const maxMembers = Number(
+    circle.rawCircle?.maxMembers || circle.totalPositions
+  );
+  const collateralLocked = calculateCollateral(circle.contribution, maxMembers);
+
+  // Collateral Required: Based on currentMembers (what's actually needed for the circle)
+  const currentMembers = Number(
+    circle.rawCircle?.currentMembers || circle.totalPositions
+  );
   const collateralRequired = calculateCollateral(
     circle.contribution,
-    circle.totalPositions
+    currentMembers
   );
-  const minMembersToStart = getMinMembersToStart(circle.totalPositions);
+
+  const minMembersToStart = getMinMembersToStart(maxMembers);
   const ultimatumPeriod = getUltimatumPeriod(circle.frequency);
 
   // Determine circle type (public/private)
@@ -265,6 +277,7 @@ const CircleDetailsModal: React.FC<CircleDetailsModalProps> = ({
             <CircleOverviewTab
               circle={circle}
               colors={colors}
+              collateralLocked={collateralLocked}
               collateralRequired={collateralRequired}
               minMembersToStart={minMembersToStart}
               ultimatumPeriod={ultimatumPeriod}


### PR DESCRIPTION
- Added 'Initial Expected Members' field to show originally proposed maxMembers
- Display 'Collateral Locked' based on maxMembers (what members actually locked when joining)
- Display 'Collateral Required' based on currentMembers (what's actually needed for the circle)
- Calculate both collateral values in CircleDetailsModal and pass to CircleOverviewTab
- Provides clear visibility into the difference between proposed and actual circle size