### PR TITLE
fix: use correct  variable in singleCircleQuery

### DIFF
--- a/src/hooks/useCircleSavings.ts
+++ b/src/hooks/useCircleSavings.ts
@@ -573,7 +573,7 @@ const singleCircleQuery = gql`
 
     # Collateral returns for these circles
     collateralReturneds(
-      where: { circleId_in: $circleIds }
+      where: { circleId: $circleId }
       orderBy: transaction__blockTimestamp
       orderDirection: desc
     ) {


### PR DESCRIPTION
Changed collateralReturneds filter from  to  to fix 'Circle not found' error on join page