### PR TITLE
refactor: focus circle history exclusively on forfeiture tracking

### DIFF
--- a/src/components/ActiveCircleCard.tsx
+++ b/src/components/ActiveCircleCard.tsx
@@ -347,7 +347,7 @@ const ActiveCircleCard: React.FC<ActiveCircleCardProps> = ({
         >
           Collateralized
         </span>
-        {(circle.latePayCount || 0) > 0 && (
+        {(circle.forfeitCount || 0) > 0 && (
           <span
             className="text-[10px] sm:text-xs px-2 py-0.5 rounded-full whitespace-nowrap border"
             style={{
@@ -356,8 +356,8 @@ const ActiveCircleCard: React.FC<ActiveCircleCardProps> = ({
               borderColor: "#FFEDD5",
             }}
           >
-            {circle.latePayCount} Late Pay Record
-            {circle.latePayCount !== 1 ? "s" : ""}
+            {circle.forfeitCount} Forfeit Record
+            {circle.forfeitCount !== 1 ? "s" : ""}
           </span>
         )}
       </div>

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -116,7 +116,7 @@ export interface ActiveCircle {
   isForfeitedThisRound?: boolean;
   forfeitedAmount?: bigint;
   forfeitedContributionPortion?: bigint;
-  latePayCount?: number;
+  forfeitCount?: number;
 
   // Withdrawal eligibility fields
   canWithdrawCollateral?: boolean;

--- a/src/pages/Circles.tsx
+++ b/src/pages/Circles.tsx
@@ -98,11 +98,11 @@ const Circles: React.FC = () => {
       // Check if user is a member
       const isMember = circle.currentPosition > 0;
 
-      // Check if user was forfeited or has late pay record
+      // Check if user was forfeited or has forfeit record
       const isForfeited = circle.isForfeited;
-      const hasLatePay = (circle.latePayCount || 0) > 0;
+      const hasForfeit = (circle.forfeitCount || 0) > 0;
 
-      return isCreator || isMember || isForfeited || hasLatePay;
+      return isCreator || isMember || isForfeited || hasForfeit;
     });
 
     const active = involvedCircles.filter((c) => {
@@ -121,8 +121,8 @@ const Circles: React.FC = () => {
       // 2. Withdrawn (Circle status OR User specific withdrawal OR Dead)
       if (c.status === "dead" || c.hasWithdrawn) return true;
 
-      // 3. Forfeited or Late record (Show in history even if still active)
-      if (c.isForfeited || (c.latePayCount || 0) > 0) return true;
+      // 3. Forfeited record (Show in history even if still active)
+      if (c.isForfeited || (c.forfeitCount || 0) > 0) return true;
 
       // 4. Payout Received by current user
       // Track in history even if still active, as a record of success
@@ -308,10 +308,10 @@ const Circles: React.FC = () => {
                 className="text-xs md:text-sm mb-2"
                 style={{ color: colors.textLight }}
               >
-                Late Pen.
+                Forfeits
               </div>
               <div className="text-xl md:text-2xl font-bold text-orange-500">
-                {allCircles.reduce((sum, c) => sum + (c.latePayCount || 0), 0)}
+                {allCircles.reduce((sum, c) => sum + (c.forfeitCount || 0), 0)}
               </div>
             </div>
           </div>
@@ -396,13 +396,13 @@ const Circles: React.FC = () => {
                   const hasWithdrawn =
                     circle.hasWithdrawn || circle.status === "dead";
                   const isForfeited = circle.isForfeited;
-                  const hasLatePay = (circle.latePayCount || 0) > 0;
+                  const hasForfeit = (circle.forfeitCount || 0) > 0;
 
                   const statusInfo = [];
                   let detailsText;
-                  if (hasLatePay) {
+                  if (hasForfeit) {
                     statusInfo.push({
-                      label: "Late Penalty",
+                      label: "Forfeited",
                       icon: (
                         <AlertOctagon
                           size={16}
@@ -475,10 +475,10 @@ const Circles: React.FC = () => {
                           })}
                         </span>
                       )}
-                      {hasLatePay && (
+                      {hasForfeit && (
                         <span className="text-xs md:text-sm text-orange-600 font-medium">
-                          {circle.latePayCount} Late Pay Record
-                          {circle.latePayCount !== 1 ? "s" : ""}
+                          {circle.forfeitCount} Forfeiture Record
+                          {circle.forfeitCount !== 1 ? "s" : ""}
                         </span>
                       )}
                       {circle.status === "completed" &&
@@ -553,7 +553,7 @@ const Circles: React.FC = () => {
                               <span>{info.label}</span>
                             </div>
                           ))}
-                          {hasLatePay && (
+                          {hasForfeit && (
                             <span className="text-[10px] md:text-xs font-bold text-orange-500 mr-1 whitespace-nowrap">
                               Deduction from collateral: $
                               {(


### PR DESCRIPTION
- Rename latePayCount to forfeitCount across interfaces and components
- Refactor circleTransformer to process only member forfeiture events
- Implement robust isUserMatch to handle subgraph address variations (object vs string)
- Update ActiveCircleCard and Circles UI to display 'Forfeiture Record' and 'Forfeiture' stats
- Remove late payment logic from circle history and financial calculation metrics