### PR TITLE
feat: optimize subgraph error handling and UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { NotificationsProvider } from "./contexts/NotificationsContext";
 import { Toaster } from "sonner";
 import PWAInstallPrompt from "./components/PWAInstallPrompt";
 import SkeletonPage from "./components/SkeletonPage";
+import DataErrorState from "./components/DataErrorState";
 
 // Lazy load page components for code-splitting
 const Dashboard = lazy(() => import("./pages/Dashboard"));
@@ -40,8 +41,13 @@ interface AppProps {
 
 function App({ client }: AppProps) {
   const account = useActiveAccount();
-  const { hasProfile, isLoading, profile, refreshProfile } =
-    useUserProfile(client);
+  const {
+    hasProfile,
+    isLoading,
+    profile,
+    refreshProfile,
+    error: profileError,
+  } = useUserProfile(client);
 
   // const [showLinkContact, setShowLinkContact] = useState(false);
 
@@ -94,7 +100,22 @@ function App({ client }: AppProps) {
             <AutoConnectWallet />
 
             {/* Loading state while checking profile or initializing */}
-            {account && (isLoading || hasProfile === null) && <SkeletonPage />}
+            {account &&
+              (isLoading || (hasProfile === null && !profileError)) && (
+                <SkeletonPage />
+              )}
+
+            {/* Error state if data fetching fails */}
+            {account && profileError && hasProfile === null && (
+              <DataErrorState
+                onRetry={refreshProfile}
+                message={
+                  profileError.includes("database unavailable")
+                    ? "Our database is currently taking a break. We're working to wake it up and get you back in!"
+                    : undefined
+                }
+              />
+            )}
 
             {/* Private Routes - only show when authenticated, has profile, and profile is loaded */}
             {showDashboard && !isLoading && !isInvalidDashboardId() && (

--- a/src/components/ActiveCircles.tsx
+++ b/src/components/ActiveCircles.tsx
@@ -35,6 +35,7 @@ const ActiveCircles: React.FC<ActiveCirclesProps> = ({ colors, client }) => {
     getLateMembersForCircle,
     forfeitures,
     isLoading,
+    error,
     initiateVoting,
     castVote,
     executeVote,
@@ -173,6 +174,29 @@ const ActiveCircles: React.FC<ActiveCirclesProps> = ({ colors, client }) => {
         {[1, 2, 3].map((i) => (
           <CircleCardSkeleton key={i} />
         ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className="rounded-2xl p-8 shadow-sm border text-center space-y-4"
+        style={{ backgroundColor: colors.surface, borderColor: colors.border }}
+      >
+        <div className="text-red-500 mb-2">
+          <Users size={48} className="mx-auto opacity-20" />
+        </div>
+        <p style={{ color: colors.text }} className="font-semibold">
+          It's Not You, It's Us
+        </p>
+        <p
+          style={{ color: colors.textLight }}
+          className="text-sm max-w-xs mx-auto"
+        >
+          We're having a little trouble finding your savings circles. We'll have
+          them back for you soon!
+        </p>
       </div>
     );
   }

--- a/src/components/DataErrorState.tsx
+++ b/src/components/DataErrorState.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { useThemeColors } from "../hooks/useThemeColors";
+import { RefreshCcw, WifiOff } from "lucide-react";
+
+interface DataErrorStateProps {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+  isSyncing?: boolean;
+}
+
+const DataErrorState: React.FC<DataErrorStateProps> = ({
+  title = "It's Not You, It's Us",
+  message = "Our data server is having a little trouble. We're working to get things back on track as quickly as possible.",
+  onRetry,
+  isSyncing = false,
+}) => {
+  const colors = useThemeColors();
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-6 text-center"
+      style={{ backgroundColor: colors.background }}
+    >
+      <div
+        className="w-20 h-20 rounded-3xl flex items-center justify-center mb-8 animate-pulse"
+        style={{ backgroundColor: colors.errorBg, color: colors.errorBorder }}
+      >
+        {isSyncing ? (
+          <RefreshCcw size={40} className="animate-spin" />
+        ) : (
+          <WifiOff size={40} />
+        )}
+      </div>
+
+      <h1 className="text-2xl font-bold mb-3" style={{ color: colors.text }}>
+        {title}
+      </h1>
+
+      <p
+        className="text-base mb-10 max-w-xs leading-relaxed"
+        style={{ color: colors.textLight }}
+      >
+        {message}
+      </p>
+
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="flex items-center gap-2 px-8 py-4 rounded-2xl font-semibold transition-all active:scale-95 shadow-lg"
+          style={{
+            backgroundColor: colors.primary,
+            color: "#FFF",
+            boxShadow: `0 10px 20px ${colors.primary}30`,
+          }}
+        >
+          <RefreshCcw size={18} />
+          Try Again
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default DataErrorState;


### PR DESCRIPTION
Implement strict 5s/7s network timeouts and disable retries for subgraph queries. Add a dedicated error UI for database/connectivity issues to prevent infinite loading states. Update hook logic to surface query errors immediately.