### PR TITLE
feat: add push notification reminder modal for unsubscribed users

### DIFF
--- a/src/modals/PushNotificationReminderModal.tsx
+++ b/src/modals/PushNotificationReminderModal.tsx
@@ -1,0 +1,245 @@
+import React, { useState } from "react";
+import { useThemeColors } from "../hooks/useThemeColors";
+import { useNotifications } from "../contexts/NotificationsContext";
+import { Bell, X, Zap, Clock, DollarSign, Target } from "lucide-react";
+import { toast } from "sonner";
+
+interface PushNotificationReminderModalProps {
+  onClose: () => void;
+}
+
+const PushNotificationReminderModal: React.FC<
+  PushNotificationReminderModalProps
+> = ({ onClose }) => {
+  const colors = useThemeColors();
+  const { togglePushNotifications } = useNotifications();
+  const [isEnabling, setIsEnabling] = useState(false);
+
+  const handleEnableNotifications = async () => {
+    setIsEnabling(true);
+    try {
+      await togglePushNotifications();
+      // Mark as completed (user enabled notifications)
+      localStorage.setItem(
+        "Circlepot_push_reminder_state",
+        JSON.stringify({
+          lastShown: Date.now(),
+          snoozeUntil: null,
+          enabled: true,
+        }),
+      );
+      onClose();
+    } catch (error) {
+      console.error("Failed to enable push notifications:", error);
+      // Don't close modal if there was an error
+    } finally {
+      setIsEnabling(false);
+    }
+  };
+
+  const handleMaybeLater = () => {
+    // Snooze for 3 days - notifications are critical, we'll remind again
+    const threeDaysFromNow = Date.now() + 3 * 24 * 60 * 60 * 1000;
+    localStorage.setItem(
+      "Circlepot_push_reminder_state",
+      JSON.stringify({
+        lastShown: Date.now(),
+        snoozeUntil: threeDaysFromNow,
+        enabled: false,
+      }),
+    );
+    toast.info("We'll remind you in 3 days");
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4 animate-in fade-in duration-300">
+      <div
+        className="rounded-3xl shadow-2xl p-6 w-full max-w-md relative animate-in zoom-in-95 duration-300"
+        style={{ backgroundColor: colors.surface }}
+      >
+        {/* Close button */}
+        <button
+          onClick={handleMaybeLater}
+          className="absolute top-4 right-4 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          style={{ color: colors.textLight }}
+        >
+          <X size={20} />
+        </button>
+
+        {/* Icon with animation */}
+        <div className="flex justify-center mb-4">
+          <div
+            className="relative p-4 rounded-full animate-pulse"
+            style={{
+              backgroundColor: colors.accentBg,
+            }}
+          >
+            <div
+              className="absolute inset-0 rounded-full animate-ping opacity-20"
+              style={{ backgroundColor: colors.primary }}
+            />
+            <Bell
+              size={40}
+              className="relative z-10"
+              style={{ color: colors.primary }}
+            />
+          </div>
+        </div>
+
+        {/* Title */}
+        <h2
+          className="text-2xl font-bold text-center mb-2"
+          style={{ color: colors.text }}
+        >
+          Stay in the Loop!
+        </h2>
+
+        {/* Subtitle */}
+        <p
+          className="text-center mb-6 text-sm"
+          style={{ color: colors.textLight }}
+        >
+          Enable push notifications to never miss important updates about your
+          savings circles and goals.
+        </p>
+
+        {/* Benefits */}
+        <div className="space-y-3 mb-6">
+          <div
+            className="flex items-start gap-3 p-3 rounded-xl"
+            style={{ backgroundColor: colors.accentBg }}
+          >
+            <div
+              className="p-2 rounded-lg shrink-0"
+              style={{ backgroundColor: colors.successBg }}
+            >
+              <Zap size={18} style={{ color: colors.primary }} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h4
+                className="font-semibold text-sm mb-1"
+                style={{ color: colors.text }}
+              >
+                Instant Circle Updates
+              </h4>
+              <p className="text-xs" style={{ color: colors.textLight }}>
+                Get notified when members join, contribute, or receive payouts
+              </p>
+            </div>
+          </div>
+
+          <div
+            className="flex items-start gap-3 p-3 rounded-xl"
+            style={{ backgroundColor: colors.accentBg }}
+          >
+            <div
+              className="p-2 rounded-lg shrink-0"
+              style={{ backgroundColor: colors.errorBg }}
+            >
+              <Clock size={18} style={{ color: "#ef4444" }} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h4
+                className="font-semibold text-sm mb-1"
+                style={{ color: colors.text }}
+              >
+                Payment Deadlines
+              </h4>
+              <p className="text-xs" style={{ color: colors.textLight }}>
+                Never miss a contribution deadline with timely reminders
+              </p>
+            </div>
+          </div>
+
+          <div
+            className="flex items-start gap-3 p-3 rounded-xl"
+            style={{ backgroundColor: colors.accentBg }}
+          >
+            <div
+              className="p-2 rounded-lg shrink-0"
+              style={{ backgroundColor: colors.successBg }}
+            >
+              <DollarSign size={18} style={{ color: colors.primary }} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h4
+                className="font-semibold text-sm mb-1"
+                style={{ color: colors.text }}
+              >
+                Payout Alerts
+              </h4>
+              <p className="text-xs" style={{ color: colors.textLight }}>
+                Celebrate instantly when you receive your circle payout
+              </p>
+            </div>
+          </div>
+
+          <div
+            className="flex items-start gap-3 p-3 rounded-xl"
+            style={{ backgroundColor: colors.accentBg }}
+          >
+            <div
+              className="p-2 rounded-lg shrink-0"
+              style={{ backgroundColor: colors.accentBg }}
+            >
+              <Target size={18} style={{ color: "#f97316" }} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h4
+                className="font-semibold text-sm mb-1"
+                style={{ color: colors.text }}
+              >
+                Goal Milestones
+              </h4>
+              <p className="text-xs" style={{ color: colors.textLight }}>
+                Track your progress with milestone notifications
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="space-y-3">
+          <button
+            onClick={handleEnableNotifications}
+            disabled={isEnabling}
+            className="w-full py-3 px-4 rounded-xl font-bold text-white shadow-lg hover:shadow-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ backgroundColor: colors.primary }}
+          >
+            {isEnabling ? (
+              <span className="flex items-center justify-center gap-2">
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                Enabling...
+              </span>
+            ) : (
+              "Enable Notifications"
+            )}
+          </button>
+
+          <button
+            onClick={handleMaybeLater}
+            className="w-full py-3 px-4 rounded-xl font-semibold transition-all border-2"
+            style={{
+              borderColor: colors.border,
+              color: colors.text,
+              backgroundColor: "transparent",
+            }}
+          >
+            Maybe Later
+          </button>
+        </div>
+
+        {/* Privacy note */}
+        <p
+          className="text-xs text-center mt-4 px-2"
+          style={{ color: colors.textLight }}
+        >
+          You can change your notification preferences anytime in Settings
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default PushNotificationReminderModal;

--- a/src/utils/pushNotificationManager.ts
+++ b/src/utils/pushNotificationManager.ts
@@ -1,7 +1,9 @@
 import type { PushSubscriptionData } from "../types/notifications";
 
 const VAPID_PUBLIC_KEY = import.meta.env.VITE_VAPID_PUBLIC_KEY;
-const NOTIFICATION_API_URL = import.meta.env.VITE_NOTIFICATION_API_URL || "http://localhost:3001/api/notifications";
+const NOTIFICATION_API_URL =
+  import.meta.env.VITE_NOTIFICATION_API_URL ||
+  "http://localhost:3001/api/notifications";
 
 /**
  * Utility function to convert a base64 string to Uint8Array
@@ -54,7 +56,7 @@ export function isPushNotificationSupported(): boolean {
  */
 export async function subscribeToPushNotifications(
   userAddress: string,
-  preferences: any
+  preferences: any,
 ): Promise<any> {
   if (!isPushNotificationSupported()) {
     return null;
@@ -62,7 +64,7 @@ export async function subscribeToPushNotifications(
 
   if (!VAPID_PUBLIC_KEY) {
     throw new Error(
-      "Push notifications are not configured. Please contact support."
+      "Push notifications are not configured. Please contact support.",
     );
   }
 
@@ -71,7 +73,7 @@ export async function subscribeToPushNotifications(
     const permission = await requestNotificationPermission();
     if (permission === "denied") {
       throw new Error(
-        "Notification permission denied. Please enable notifications in your browser settings."
+        "Notification permission denied. Please enable notifications in your browser settings.",
       );
     }
     if (permission !== "granted") {
@@ -124,7 +126,7 @@ export async function subscribeToPushNotifications(
  * Unsubscribe from push notifications
  */
 export async function unsubscribeFromPushNotifications(
-  userAddress: string
+  userAddress: string,
 ): Promise<boolean> {
   if (!isPushNotificationSupported()) {
     return false;
@@ -163,7 +165,7 @@ export async function unsubscribeFromPushNotifications(
  */
 export async function updateNotificationPreferences(
   userAddress: string,
-  preferences: any
+  preferences: any,
 ): Promise<any> {
   if (!NOTIFICATION_API_URL) {
     return;
@@ -196,7 +198,7 @@ export async function updateNotificationPreferences(
  * Send subscription data to backend
  */
 async function sendSubscriptionToBackend(
-  subscriptionData: PushSubscriptionData
+  subscriptionData: PushSubscriptionData,
 ): Promise<any> {
   try {
     const response = await fetch(`${NOTIFICATION_API_URL}/subscribe`, {
@@ -210,7 +212,8 @@ async function sendSubscriptionToBackend(
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
       throw new Error(
-        errorData.error || `Failed to send subscription to backend: ${response.statusText}`
+        errorData.error ||
+          `Failed to send subscription to backend: ${response.statusText}`,
       );
     }
 
@@ -242,4 +245,74 @@ export async function getPushSubscriptionStatus(): Promise<{
   } catch (error) {
     return { isSubscribed: false, subscription: null };
   }
+}
+
+/**
+ * Push Notification Reminder Modal State Management
+ */
+
+interface PushReminderState {
+  lastShown: number | null; // Last time modal was shown
+  snoozeUntil: number | null; // If "Maybe later" was clicked
+  enabled: boolean; // If user enabled notifications through the modal
+}
+
+const REMINDER_STORAGE_KEY = "Circlepot_push_reminder_state";
+
+/**
+ * Get the current reminder state from localStorage
+ */
+export function getPushReminderState(): PushReminderState {
+  try {
+    const stored = localStorage.getItem(REMINDER_STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (error) {
+    console.error("Failed to load push reminder state:", error);
+  }
+
+  // Default state
+  return {
+    lastShown: null,
+    snoozeUntil: null,
+    enabled: false,
+  };
+}
+
+/**
+ * Check if the push notification reminder modal should be shown
+ * Returns true if all conditions are met:
+ * - Browser supports push notifications
+ * - User is not already subscribed
+ * - User hasn't enabled yet
+ * - Snooze period has expired (if set)
+ */
+export async function shouldShowPushReminder(): Promise<boolean> {
+  // Check if browser supports push notifications
+  if (!isPushNotificationSupported()) {
+    return false;
+  }
+
+  // Check if user is already subscribed
+  const { isSubscribed } = await getPushSubscriptionStatus();
+  if (isSubscribed) {
+    return false;
+  }
+
+  // Check reminder state
+  const state = getPushReminderState();
+
+  // User already enabled (edge case where subscription failed but user tried)
+  if (state.enabled) {
+    return false;
+  }
+
+  // Check if snoozed
+  if (state.snoozeUntil && Date.now() < state.snoozeUntil) {
+    return false;
+  }
+
+  // All conditions met - show the reminder
+  return true;
 }


### PR DESCRIPTION
Implement a non-intrusive modal that prompts users to enable push notifications
if their browser supports it and they haven't subscribed yet. The modal includes
smart snooze logic with localStorage persistence.
Features:
- Beautiful animated modal with benefit cards highlighting key features
- Two user actions: Enable Now or Maybe Later (3-day snooze)
- No permanent dismissal - notifications are critical for circle deadlines
- Smart display conditions checking browser support and subscription status
- 2-second delay after dashboard load for better UX
- LocalStorage state management to track user preferences
- Theme-aware design matching app's color system
- Toast notifications for user feedback
Changes:
- Add PushNotificationReminderModal component with premium UI design
- Add shouldShowPushReminder() helper to check display conditions
- Add getPushReminderState() helper for localStorage state management
- Integrate modal into App.tsx with conditional rendering logic
- Shows only when: browser supports push, user not subscribed, not enabled, snooze expired
The modal appears 2 seconds after dashboard loads and will remind users every
3 days if they choose "Maybe Later" to ensure they don't miss critical updates
about payments, payouts, and circle activities.