### PR TITLE
fix: ensure biometric registration when enabling via reminder modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,6 +299,8 @@ function App({ client }: AppProps) {
                 <BiometricReminderModal
                   onClose={() => setShowBiometricReminder(false)}
                   userId={String(profile.accountId)}
+                  userName={profile.username || ""}
+                  userEmail={profile.email || ""}
                 />
               )}
 

--- a/src/utils/biometricReminderManager.ts
+++ b/src/utils/biometricReminderManager.ts
@@ -10,7 +10,7 @@ interface BiometricReminderState {
 }
 
 const REMINDER_STORAGE_KEY = "Circlepot_biometric_reminder_state";
-const DAYS_BEFORE_SHOWING = 3; // Show reminder after 3 days
+const DAYS_BEFORE_SHOWING = 1; // Show reminder after 1 days
 const SNOOZE_DAYS = 5; // Snooze for 5 days when "Maybe Later" is clicked
 
 /**


### PR DESCRIPTION
- Updated BiometricReminderModal to call registerBiometric via WebAuthn instead of just toggling local state
- Passed user profile details (userName, userEmail) to the modal for proper credential creation
- Adjusted reminder threshold to 1 day for better initial user engagement
- Prevents potential account lockout caused by enabled biometric state without a registered credential